### PR TITLE
feat: allow customising instance creation

### DIFF
--- a/src/ClassFactory.php
+++ b/src/ClassFactory.php
@@ -58,13 +58,22 @@ abstract class ClassFactory
             $this->state($state);
         }
 
-        $object = new $this->class(...$this->collapseStates());
+        $object = $this->newInstance($this->collapseStates());
 
         foreach ($this->lateTransformers as $transformer) {
             $transformer($object);
         }
 
         return $object;
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     * @return T
+     */
+    protected function newInstance(array $properties): object
+    {
+        return new $this->class(...$properties);
     }
 
     /** @return array<string, mixed> */


### PR DESCRIPTION
In some cases I would like to customise the way instances are created. For example, with `spatie/laravel-data`, I might want to call `MyData::validateAndCreate()` instead of the constructor by default.
